### PR TITLE
Add Twilio support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Keycloak 2FA SMS Authenticator
 
-Keycloak Authentication Provider implementation to get a 2nd-factor authentication with a OTP/code/token send via SMS (through AWS SNS).
+Keycloak Authentication Provider implementation to get a 2nd-factor authentication with a OTP/code/token send via SMS (through Twilio).
 
 _Demo purposes only!_
 
@@ -15,3 +15,14 @@ Or, just watch my **video** about this 2FA SMS SPI:
 [![](http://img.youtube.com/vi/GQi19817fFk/maxresdefault.jpg)](http://www.youtube.com/watch?v=GQi19817fFk "")
 
 [![](http://img.youtube.com/vi/FHJ5WOx1es0/maxresdefault.jpg)](http://www.youtube.com/watch?v=FHJ5WOx1es0 "")
+
+## Twilio Configuration
+
+To use Twilio for sending SMS, you need to configure your Twilio account SID, auth token, and the phone number you want to send messages from.
+
+1. Sign up for a Twilio account at https://www.twilio.com/ and get your Account SID and Auth Token.
+2. In the Keycloak admin console, go to the Authentication section and select the "SMS Authentication" flow.
+3. Edit the configuration of the "SMS Authentication" flow and add the following configuration properties:
+   - `twilioAccountSid`: Your Twilio Account SID
+   - `twilioAuthToken`: Your Twilio Auth Token
+   - `twilioFromPhoneNumber`: The phone number you want to send messages from (must be a verified Twilio number)

--- a/src/main/java/dasniko/keycloak/authenticator/gateway/SmsServiceFactory.java
+++ b/src/main/java/dasniko/keycloak/authenticator/gateway/SmsServiceFactory.java
@@ -16,7 +16,7 @@ public class SmsServiceFactory {
 			return (phoneNumber, message) ->
 				log.warn(String.format("***** SIMULATION MODE ***** Would send SMS to %s with text: %s", phoneNumber, message));
 		} else {
-			return new AwsSmsService(config);
+			return new TwilioSmsService(config);
 		}
 	}
 

--- a/src/main/java/dasniko/keycloak/authenticator/gateway/TwilioSmsService.java
+++ b/src/main/java/dasniko/keycloak/authenticator/gateway/TwilioSmsService.java
@@ -1,0 +1,28 @@
+package dasniko.keycloak.authenticator.gateway;
+
+import com.twilio.Twilio;
+import com.twilio.rest.api.v2010.account.Message;
+import com.twilio.type.PhoneNumber;
+
+import java.util.Map;
+
+public class TwilioSmsService implements SmsService {
+
+    private final String fromPhoneNumber;
+
+    public TwilioSmsService(Map<String, String> config) {
+        String accountSid = config.get("twilioAccountSid");
+        String authToken = config.get("twilioAuthToken");
+        fromPhoneNumber = config.get("twilioFromPhoneNumber");
+        Twilio.init(accountSid, authToken);
+    }
+
+    @Override
+    public void send(String phoneNumber, String message) {
+        Message.creator(
+                new PhoneNumber(phoneNumber),
+                new PhoneNumber(fromPhoneNumber),
+                message
+        ).create();
+    }
+}


### PR DESCRIPTION
Add support for Twilio SMS service for 2FA.

* **TwilioSmsService.java**: Create a new class `TwilioSmsService` implementing `SmsService`. Add a constructor that initializes Twilio with account SID and auth token. Implement the `send` method to send SMS using Twilio API.
* **SmsServiceFactory.java**: Modify the `get` method to return an instance of `TwilioSmsService` instead of `AwsSmsService`.
* **README.md**: Update the README to reflect the change from AWS SNS to Twilio for sending SMS. Add instructions on how to configure Twilio account SID, auth token, and the phone number to send messages from.

